### PR TITLE
Add Hugo image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM            alpine:3.7
 
+LABEL           maintainer="https://github.com/idi-ops"
+
 ENV             HUGO_VERSION=0.40.2
 ENV             HUGO_DOWNLOAD=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
-RUN             wget -q -O - $HUGO_DOWNLOAD | tar xvz -C /
+RUN             wget -q -O - $HUGO_DOWNLOAD | tar xvz -C /usr/local/bin
+
+ONBUILD COPY    . /src
+ONBUILD WORKDIR /src
+ONBUILD RUN     hugo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM            alpine:3.7
+FROM alpine:latest
 
-LABEL           maintainer="https://github.com/idi-ops"
+LABEL maintainer="https://github.com/idi-ops"
 
-ENV             HUGO_VERSION=0.40.2
-ENV             HUGO_DOWNLOAD=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
-RUN             wget -q -O - $HUGO_DOWNLOAD | tar xvz -C /usr/local/bin
+ENV HUGO_VERSION=0.42.2
+ENV HUGO_DOWNLOAD=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+
+RUN wget -q -O - $HUGO_DOWNLOAD | tar xvz -C /usr/local/bin
 
 ONBUILD COPY    . /src
 ONBUILD WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM            alpine:3.7
+
+ENV             HUGO_VERSION=0.40.2
+ENV             HUGO_DOWNLOAD=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+RUN             wget -q -O - $HUGO_DOWNLOAD | tar xvz -C /

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018, IDI Ops
+Copyright (c) 2018, OCAD University
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # docker-hugo
+
+Docker image for the Hugo static site generator
+
+## Generate website
+
+ You need to mount the `/src` directory as Docker volumes so Hugo inside the container has access to your code and to write the artifacts:
+
+```
+$ docker run --rm -ti -v $PWD:/src inclusivedesign/hugo --destination=/src
+```
+
+## Watch for changes
+
+```
+$ docker run --rm -ti -P -v $PWD:/src inclusivedesign/hugo server 
+```
+
+Your website will be available on http://localhost:1313

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Docker image for the Hugo static site generator
 
+## Use as base image
+
+The `hugo` image has these commands:
+
+```
+ONBUILD COPY    . /src
+ONBUILD WORKDIR /src
+ONBUILD RUN     hugo
+```
+
+You can just use it and the site will be generated automatically on build:
+
+```
+FROM inclusivedesign/hugo as builder
+
+FROM nginx:alpine
+COPY --from=builder /src/public /usr/share/nginx/html
+```
+
 ## Generate website
 
  You need to mount the `/src` directory as Docker volumes so Hugo inside the container has access to your code and to write the artifacts:
@@ -13,7 +32,7 @@ $ docker run --rm -ti -v $PWD:/src inclusivedesign/hugo --destination=/src
 ## Watch for changes
 
 ```
-$ docker run --rm -ti -P -v $PWD:/src inclusivedesign/hugo server 
+$ docker run --rm -ti --publish-all -v $PWD:/src inclusivedesign/hugo server --destination=/src
 ```
 
 Your website will be available on http://localhost:1313


### PR DESCRIPTION
Super simply Docker image to build Hugo websites (based on Alpine Linux so it's easier to add additional tools if needed -- otherwise we could use Busybox to make the image smaller).

Example usage (using Docker multi-stage builds):

```
FROM inclusivedesign/hugo as builder

FROM nginx:alpine
COPY --from=builder /src/public /usr/share/nginx/html
```